### PR TITLE
builder/openstack: lock to fork for now to compile [GH-1625]

### DIFF
--- a/builder/openstack/access_config.go
+++ b/builder/openstack/access_config.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
-	"github.com/rackspace/gophercloud"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 // AccessConfig is for common configuration related to openstack access

--- a/builder/openstack/artifact.go
+++ b/builder/openstack/artifact.go
@@ -2,8 +2,9 @@ package openstack
 
 import (
 	"fmt"
-	"github.com/rackspace/gophercloud"
 	"log"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 // Artifact is an artifact implementation that contains built images.

--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -8,8 +8,9 @@ import (
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
-	"github.com/rackspace/gophercloud"
 	"log"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 // The unique ID for this builder

--- a/builder/openstack/server.go
+++ b/builder/openstack/server.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"github.com/mitchellh/multistep"
 	"github.com/racker/perigee"
-	"github.com/rackspace/gophercloud"
 	"log"
 	"time"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 // StateRefreshFunc is a function type used for StateChangeConf that is

--- a/builder/openstack/ssh.go
+++ b/builder/openstack/ssh.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"github.com/mitchellh/multistep"
-	"github.com/rackspace/gophercloud"
 	"time"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 // SSHAddress returns a function that can be given to the SSH communicator

--- a/builder/openstack/step_allocate_ip.go
+++ b/builder/openstack/step_allocate_ip.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"github.com/rackspace/gophercloud"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 type StepAllocateIp struct {

--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"github.com/rackspace/gophercloud"
 	"log"
 	"time"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 type stepCreateImage struct{}

--- a/builder/openstack/step_key_pair.go
+++ b/builder/openstack/step_key_pair.go
@@ -5,10 +5,11 @@ import (
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/common/uuid"
 	"github.com/mitchellh/packer/packer"
-	"github.com/rackspace/gophercloud"
 	"log"
 	"os"
 	"runtime"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 type StepKeyPair struct {

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"github.com/rackspace/gophercloud"
 	"log"
+
+	"github.com/mitchellh/gophercloud-fork-40444fb"
 )
 
 type StepRunSourceServer struct {


### PR DESCRIPTION
Your fork no longer builds due to a dependency that has been removed. @mitchellh fixed it and this is just a PR to cherry-pick that fix into your handy branch whilst we wait for WinRM support to be added to packer.

Thanks for your efforts on this! I'm new to Windows automation and had feared that I was going to be driven into a torment of manual button clicking. Fortunately I found your work. Hooray!
